### PR TITLE
Add Page Linking to Official Zilog Manual

### DIFF
--- a/docs/instructions.rst
+++ b/docs/instructions.rst
@@ -1,0 +1,8 @@
+=================================
+General Instruction Documentation
+=================================
+
+.. toctree::
+  :maxdepth: 2
+
+  instructions/ez80

--- a/docs/instructions/ez80.rst
+++ b/docs/instructions/ez80.rst
@@ -1,0 +1,7 @@
+Instructions
+--------
+
+**Read The Manual**
+    Zilog has an `official eZ80 manual <https://zilog.com/appnotes_download.php?FromPage=DocTree&dn=UM0077&ft=User%20Manual&f=YUhSMGNEb3ZMM2QzZHk1NmFXeHZaeTVqYjIwdlpHOWpjeTlWVFRBd056Y3VjR1Jt`_
+    
+    This manual documents most instructions necessary.


### PR DESCRIPTION
There is an official manual for the eZ80 which can be used as a reference. This PR attempts to create a page to link to it.